### PR TITLE
fix thousand number e.g. "20,408" to be converted to "20.41"

### DIFF
--- a/mara_google_sheet_downloader/columns_definition.py
+++ b/mara_google_sheet_downloader/columns_definition.py
@@ -179,9 +179,7 @@ class NumericCellDefinition(CellDefinition):
         if getattr(self, 'ignore_non_numeric', False):
             input = _NUMERIC_REMOVE_NON_NUMERIC_CHARS.sub('', input)
 
-        # workaround for getting "1,0" recognized as "1.0"
-        input = input.replace(',', '.')
-        # or even '1.000,00' as '1000.00'
+        input = input.replace(',', '') # remove thousand splitter
         _input = input.split('.')
         if len(_input) > 2:
             input = ''.join(_input[:-1]) + '.' + _input[-1]


### PR DESCRIPTION
I have a sheet where I have the number

![image](https://user-images.githubusercontent.com/46843047/82927100-78d3d400-9f80-11ea-95f0-da4aaa36a13d.png)

When I download this number and define the column as float, it exports the number as "20.408" into the CSV file, which of course is then not anymore 20408.00, but, 20.41 in the postgres database (using the mara integration).

With this short fix, this does not happen anymore.
If the idea was here to support other locale formatting (e.g. german number formatting "20.408,00"), IMHO, this should be configurable and by default mara should use locale en-US when nothing else is defined.